### PR TITLE
Remove application attributes from library project

### DIFF
--- a/qrcodescanner/src/main/AndroidManifest.xml
+++ b/qrcodescanner/src/main/AndroidManifest.xml
@@ -3,8 +3,7 @@
     package="com.blikoon.qrcodescanner">
 
     <uses-permission android:name="android.permission.VIBRATE" />
-    <application android:allowBackup="true" android:label="@string/app_name"
-        android:supportsRtl="true">
+    <application>
         <activity android:name=".QrCodeActivity">
 
         </activity>


### PR DESCRIPTION
These are not needed here, but they are inherited by users of this library and require a `tools:replace` to change them.